### PR TITLE
Adjust build manager

### DIFF
--- a/Assets/Models/CubeOutline.prefab
+++ b/Assets/Models/CubeOutline.prefab
@@ -1,0 +1,117 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4908281041609623355
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6821757588227778677}
+  - component: {fileID: 4011771912043012189}
+  - component: {fileID: 8727650389471817567}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6821757588227778677
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4908281041609623355}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5344511413749937835}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4011771912043012189
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4908281041609623355}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8727650389471817567
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4908281041609623355}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 0d1c879cb7372374da1a621d77dbf59b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &9033511867729093445
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5344511413749937835}
+  m_Layer: 0
+  m_Name: CubeOutline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5344511413749937835
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9033511867729093445}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6821757588227778677}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Models/CubeOutline.prefab.meta
+++ b/Assets/Models/CubeOutline.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1f796d0f99f2c9d4b80f5a0b9767608e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_SRP_Base_2020_LTS.unitypackage.meta
+++ b/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_SRP_Base_2020_LTS.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 11b058cf3bdab1a469096c801d1e6d2b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_SRP_NatureRenderer_2020_LTS.unitypackage.meta
+++ b/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_SRP_NatureRenderer_2020_LTS.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cb26147f5c23b2041970297abae92df2
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_URP_Base_2019.3.unitypackage.meta
+++ b/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_URP_Base_2019.3.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 361c4f5413c6320489538cef89501e42
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_URP_Base_2020_LTS.unitypackage.meta
+++ b/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_URP_Base_2020_LTS.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 547692c3e4ed66b4aa23e8eda544c524
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_URP_NatureRenderer_2019.3.unitypackage.meta
+++ b/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_URP_NatureRenderer_2019.3.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 242d7a32f7a2a20488f1bd745efad998
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_URP_NatureRenderer_2020_LTS.unitypackage.meta
+++ b/Assets/Polyart/PolyartStudio/DreamscapeMeadows/DreamscapeMeadows_URP_NatureRenderer_2020_LTS.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9cdff63e5d4a07342bc5f593afe7c395
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -3195,6 +3195,7 @@ GameObject:
   - component: {fileID: 4196609734246092110}
   - component: {fileID: 1348742631}
   - component: {fileID: 1295314657219903149}
+  - component: {fileID: 7788805317328188307}
   m_Layer: 0
   m_Name: Player
   m_TagString: MainCamera
@@ -3431,6 +3432,73 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c2d0880e305ae04b97b31942e78c8bf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &7788805317328188307
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7511521097452256554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45037cf328f5665489a874998f57e6db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _buildableItems:
+  - Name: Log Wall
+    RequiredItems:
+    - Wood,15
+    Spawnables:
+      ObjectToSpawn: {fileID: 5325711560573957082, guid: 48aab697b35e0f74cb143e71b101ade8, type: 3}
+      OutlineObject: {fileID: 1021590378627858659, guid: 3aa9a5af273552f4aacfa80f8b616aeb, type: 3}
+  - Name: Log Wall (Doorway)
+    RequiredItems:
+    - Wood,15
+    Spawnables:
+      ObjectToSpawn: {fileID: 5328493721939886067, guid: 59be750a5bd589e41ab856f9198fdf0a, type: 3}
+      OutlineObject: {fileID: 586215820063795992, guid: fdd96bd3e0ed197498267c27722f34b3, type: 3}
+  - Name: Log Wall (Window)
+    RequiredItems:
+    - Wood,15
+    Spawnables:
+      ObjectToSpawn: {fileID: 6933374540963440392, guid: 4d3d20483336ff045be8ceb5ae3815f7, type: 3}
+      OutlineObject: {fileID: 1713712089762639675, guid: 090412e4d4067164ba940d31f7dd4734, type: 3}
+  - Name: Log Stairs (Short)
+    RequiredItems:
+    - Wood,15
+    Spawnables:
+      ObjectToSpawn: {fileID: 5959909905902975035, guid: 8700b9853c2ea094bbde0546f3e42ef8, type: 3}
+      OutlineObject: {fileID: 6391781037200454601, guid: 7aebfb73341c36b44b266fcd18f389ee, type: 3}
+  - Name: Log Stairs (Long)
+    RequiredItems:
+    - Wood,15
+    Spawnables:
+      ObjectToSpawn: {fileID: 7921543561513323570, guid: 1348f521b70246142ac5582f275ace2d, type: 3}
+      OutlineObject: {fileID: 1255299063320172761, guid: 6b9a63a6de37cd04d89ecf8c1b741d08, type: 3}
+  - Name: Log Floor
+    RequiredItems:
+    - Wood,15
+    Spawnables:
+      ObjectToSpawn: {fileID: 1132136422219002222, guid: b602182c0aa5e294e8f6d3cf64639015, type: 3}
+      OutlineObject: {fileID: 8891641807580690448, guid: b7797d8bad55969459e0963ce9b7208c, type: 3}
+  - Name: Stone Wall
+    RequiredItems:
+    - Stone,15
+    Spawnables:
+      ObjectToSpawn: {fileID: 6330383493804913173, guid: 66a3a4151281b65429cdc5479d3cf5de, type: 3}
+      OutlineObject: {fileID: 2641699549125229728, guid: f0656cef63a89574facf218916eb9437, type: 3}
+  - Name: Stone Wall (Doorway)
+    RequiredItems:
+    - Stone,15
+    Spawnables:
+      ObjectToSpawn: {fileID: 3990095667925011512, guid: 2d83274935a9bcc4aad0b154a82ed221, type: 3}
+      OutlineObject: {fileID: 307931847570965225, guid: 5c57ae1cfbf2c984cbb42869da21590a, type: 3}
+  - Name: Furnace
+    RequiredItems:
+    - Stone,15
+    Spawnables:
+      ObjectToSpawn: {fileID: 6825927422027586478, guid: fc1a719c06b68ba4584801d5dbf53669, type: 3}
+      OutlineObject: {fileID: 9033511867729093445, guid: 1f796d0f99f2c9d4b80f5a0b9767608e, type: 3}
 --- !u!1 &7563955356636403834
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Furnace-Buildable.prefab
+++ b/Assets/Resources/Furnace-Buildable.prefab
@@ -1,0 +1,144 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &130170381358314534
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1176005607057291814}
+  - component: {fileID: 2022765967492275150}
+  - component: {fileID: 3234965960934613654}
+  - component: {fileID: 8041077602045619566}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1176005607057291814
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 130170381358314534}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 824501171864328747}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2022765967492275150
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 130170381358314534}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3234965960934613654
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 130170381358314534}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &8041077602045619566
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 130170381358314534}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &6825927422027586478
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 824501171864328747}
+  - component: {fileID: 4083167570718844426}
+  m_Layer: 0
+  m_Name: Furnace-Buildable
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &824501171864328747
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6825927422027586478}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1176005607057291814}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4083167570718844426
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6825927422027586478}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e698fd36bbef3054a940b5647b685e1c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/Furnace-Buildable.prefab.meta
+++ b/Assets/Resources/Furnace-Buildable.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fc1a719c06b68ba4584801d5dbf53669
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/RobertBPlayground.unity
+++ b/Assets/Scenes/RobertBPlayground.unity
@@ -469,7 +469,7 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7511521097452256554, guid: 65b0362be0aabe649968e2cbf4962be8, type: 3}
   m_PrefabInstance: {fileID: 1196721700}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1000999364
+--- !u!114 &1000999374
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -478,26 +478,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1000999353}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 98be8c8ebebdf9845bb1027d1eaf848f, type: 3}
+  m_Script: {fileID: 11500000, guid: 0661450b6e4c9a34ea70b8dd0451d5fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _spawnablePrefabs:
-  - ObjectToSpawn: {fileID: 5325711560573957082, guid: 48aab697b35e0f74cb143e71b101ade8, type: 3}
-    OutlineObject: {fileID: 1021590378627858659, guid: 3aa9a5af273552f4aacfa80f8b616aeb, type: 3}
-  - ObjectToSpawn: {fileID: 5959909905902975035, guid: 8700b9853c2ea094bbde0546f3e42ef8, type: 3}
-    OutlineObject: {fileID: 6391781037200454601, guid: 7aebfb73341c36b44b266fcd18f389ee, type: 3}
-  - ObjectToSpawn: {fileID: 7921543561513323570, guid: 1348f521b70246142ac5582f275ace2d, type: 3}
-    OutlineObject: {fileID: 1255299063320172761, guid: 6b9a63a6de37cd04d89ecf8c1b741d08, type: 3}
-  - ObjectToSpawn: {fileID: 5328493721939886067, guid: 59be750a5bd589e41ab856f9198fdf0a, type: 3}
-    OutlineObject: {fileID: 586215820063795992, guid: fdd96bd3e0ed197498267c27722f34b3, type: 3}
-  - ObjectToSpawn: {fileID: 6330383493804913173, guid: 66a3a4151281b65429cdc5479d3cf5de, type: 3}
-    OutlineObject: {fileID: 2641699549125229728, guid: f0656cef63a89574facf218916eb9437, type: 3}
-  - ObjectToSpawn: {fileID: 3990095667925011512, guid: 2d83274935a9bcc4aad0b154a82ed221, type: 3}
-    OutlineObject: {fileID: 307931847570965225, guid: 5c57ae1cfbf2c984cbb42869da21590a, type: 3}
-  - ObjectToSpawn: {fileID: 6933374540963440392, guid: 4d3d20483336ff045be8ceb5ae3815f7, type: 3}
-    OutlineObject: {fileID: 1713712089762639675, guid: 090412e4d4067164ba940d31f7dd4734, type: 3}
-  - ObjectToSpawn: {fileID: 1132136422219002222, guid: b602182c0aa5e294e8f6d3cf64639015, type: 3}
-    OutlineObject: {fileID: 8891641807580690448, guid: b7797d8bad55969459e0963ce9b7208c, type: 3}
 --- !u!1 &1036310914
 GameObject:
   m_ObjectHideFlags: 0
@@ -949,6 +932,7 @@ MonoBehaviour:
   skyboxMaterial: {fileID: 2100000, guid: 14458869d885fdf4d9afa53258a80d5c, type: 2}
   timeScale: 1
   intensityScale: 0.25
+  skyboxRotation: 0
   colorStep: 0.711
   settingColor: {r: 0.8490566, g: 0.6424398, b: 0.50863296, a: 1}
   noonColor: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}

--- a/Assets/Scripts/BuildingManager.cs
+++ b/Assets/Scripts/BuildingManager.cs
@@ -29,10 +29,53 @@ public class BuildingManager : MonoBehaviour
     [SerializeField]
     private BuildableItem[] _buildableItems;
 
+    // Placement variables
+    public bool InBuildMode { get; private set; }
+    private (BuildObjectPair spawnables, Dictionary<string, int> cost) _currentBuildConfig;
+    private GameObject _activeOutline;
+    private Camera _cameraHolderCamera;
+
+    // Placement distance variables
+    private float distanceLimit = 2;
+    private float distanceDeltaSec = 2;
+    private float minDistanceLimit = 2;
+    private float maxdistanceLimit = 7;
+
     public IReadOnlyCollection<BuildableItem> BuildableItems => _buildableItems;
 
+    public event EventHandler OnExitedBuildMode;
+    public event EventHandler OnItemPlaced;
+
     // Start is called before the first frame update
-    void Start() => RecordRequiredResources();
+    void Start()
+    {
+        
+        RecordRequiredResources();
+        var cameras = GetComponentsInChildren<Camera>();
+        _cameraHolderCamera = cameras.Where(camera => camera.name == "CameraHolder").FirstOrDefault();
+
+    }
+
+    void Update()
+    {
+
+        // Handle placing the outline
+        if (InBuildMode && _activeOutline != null) { PlaceOutline(); }
+
+        // Handle adjusting the distance limit
+        float adjustmentAxisValue = Input.GetAxis("AdjustObjectDistance");
+        if (InBuildMode && (adjustmentAxisValue != 0))
+        {
+            AdjustDistanceLimit(Time.deltaTime * distanceDeltaSec * adjustmentAxisValue);
+        }
+
+        // Handle confirming the build
+        if (InBuildMode && Input.GetKeyDown(KeyCode.F)) { ConfirmPurchase(); }
+
+        // Handle cancelling
+        if (InBuildMode && Input.GetKeyDown(KeyCode.Y)) { ExitBuildMode(); }
+
+    }
 
     private void RecordRequiredResources()
     {
@@ -87,6 +130,93 @@ public class BuildingManager : MonoBehaviour
         }
 
         return false;
+
+    }
+
+    public void EnterBuildMode((BuildObjectPair spawnables, Dictionary<string, int> cost) buildConfig)
+    {
+
+        // Erase the old outline
+        if (InBuildMode) { DestroyOutline(); }
+
+        _currentBuildConfig = buildConfig;
+        _activeOutline = Instantiate(_currentBuildConfig.spawnables.OutlineObject, transform.position, transform.rotation);
+
+        InBuildMode = true;
+
+    }
+
+    private void ExitBuildMode()
+    {
+
+        InBuildMode = false;
+        _currentBuildConfig = (null, null);
+        DestroyOutline();
+        OnExitedBuildMode?.Invoke(this, EventArgs.Empty);
+
+    }
+
+    private void DestroyOutline()
+    {
+        
+        Destroy(_activeOutline);
+        _activeOutline = null;
+
+    }
+
+    private void AdjustDistanceLimit(float delta) 
+        => distanceLimit = Mathf.Clamp(distanceLimit + delta, minDistanceLimit, maxdistanceLimit);
+
+    private void PlaceOutline()
+    {
+
+        Renderer outlineRenderer = _activeOutline.GetComponentInChildren<Renderer>();
+        float yOffset = outlineRenderer == null ? 0 : outlineRenderer.bounds.size.y / 2f;
+
+        _activeOutline.transform.position = GetObjectPreviewLocation() + new Vector3(0f, yOffset, 0f);
+        _activeOutline.transform.rotation = transform.rotation;
+
+    }
+
+    private Vector3 GetObjectPreviewLocation()
+    {
+
+        // Ignore hits against the object being placed and the player
+        IEnumerable<RaycastHit> allHits = Physics.RaycastAll(_cameraHolderCamera.transform.position, _cameraHolderCamera.transform.forward, distanceLimit);
+        allHits = allHits.Where(hit => hit.collider.gameObject != _activeOutline && hit.collider.gameObject != gameObject);
+
+        // In the case that there was no raycast hits, position at the point at the end of the limit
+        if (allHits.Count() == 0)
+        {
+            Vector3 cameraForwardVector = _cameraHolderCamera.transform.forward;
+            return cameraForwardVector * distanceLimit + _cameraHolderCamera.transform.position;
+        }
+
+        // Take the closest hit to the player
+        RaycastHit hitLocation = allHits.FirstOrDefault();
+        float closestSoFar = Vector3.Distance(hitLocation.point, transform.position);
+        foreach (var hit in allHits)
+        {
+            float distance = Vector3.Distance(hit.point, transform.position);
+            if (distance < closestSoFar)
+            {
+                closestSoFar = distance;
+                hitLocation = hit;
+            }
+        }
+
+        return hitLocation.point;
+
+    }
+
+    private void ConfirmPurchase()
+    {
+
+        Instantiate(_currentBuildConfig.spawnables.ObjectToSpawn, _activeOutline.transform.position, _activeOutline.transform.rotation);
+
+        Inventory.RemoveItems(_currentBuildConfig.cost);
+        OnItemPlaced?.Invoke(this, EventArgs.Empty);
+        ExitBuildMode();
 
     }
 

--- a/Assets/Scripts/Inventory.cs
+++ b/Assets/Scripts/Inventory.cs
@@ -43,6 +43,13 @@ public class Inventory : MonoBehaviour
         _items[n] -= qty;
     }
 
+    public static void RemoveItems(IEnumerable<KeyValuePair<string, int>> toRemove)
+    {
+
+        foreach (var item in toRemove) { RemoveItem(item.Key, item.Value); }
+
+    }
+
     public static int GetCount(string n)
     {
         return _items[n];

--- a/Assets/Scripts/Testing/BuildTestScript.cs
+++ b/Assets/Scripts/Testing/BuildTestScript.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public class BuildTestScript : MonoBehaviour
+{
+
+    private BuildingManager _buildManager;
+    private IReadOnlyCollection<BuildableItem> _buildables;
+    private int _currentBuildIndex = 0;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+        _buildManager = GetComponent<BuildingManager>();
+        _buildables = _buildManager.BuildableItems;
+
+        _buildManager.OnExitedBuildMode += (_, _) => { print("Player exited build mode"); };
+        _buildManager.OnItemPlaced += (_, _) => { print("Player placed item"); };
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+
+        if (!_buildManager.InBuildMode && Input.GetKeyDown(KeyCode.T)) { LoadCurrentBuildable(); }
+
+        else if (_buildManager.InBuildMode && Input.GetKeyDown(KeyCode.R)) 
+        {
+
+            if (++_currentBuildIndex >= _buildables.Count) { _currentBuildIndex = 0; }
+
+            LoadCurrentBuildable();
+
+        }
+     
+    }
+
+    private void LoadCurrentBuildable() 
+    {
+
+        var target = _buildables.ElementAt(_currentBuildIndex);
+        _buildManager.EnterBuildMode((target.Spawnables, new Dictionary<string, int>() { }));
+
+    }
+
+}

--- a/Assets/Scripts/Testing/BuildTestScript.cs.meta
+++ b/Assets/Scripts/Testing/BuildTestScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0661450b6e4c9a34ea70b8dd0451d5fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SkySeries Freebie/FreebieHdri/Materials/SunlessCirruscover4k.mat
+++ b/Assets/SkySeries Freebie/FreebieHdri/Materials/SunlessCirruscover4k.mat
@@ -26,8 +26,8 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
-    - _Exposure: 0.3602934
-    - _Rotation: 2518.1472
+    - _Exposure: 0.20067938
+    - _Rotation: 2526.4636
     m_Colors:
     - _Tint: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
   m_BuildTextureStacks: []


### PR DESCRIPTION
Build manager can now be put into build mode and handles placing a provided buildable

**CHANGES:**
BuildManager can now be put into "build mode" and start the process for placing a provided buildable. Once it is kicked off, the BuildManager is autonomous and has events for when the player exits and/ or places the item. A BuildManager component has been placed onto the player prefab and is available for retrieval. The build manager handles deducting resources when something is constructed.

The new public properties/ methods in BuildManager are:
 - bool InBuildMode <- Property that indicates whether or not the BuildManager is in build mode (player is placing a buildable)
 - EnterBuildMode((BuildObjectPair spawnables, Dictionary<string, int> cost) buildConfig) <- Kicks the BuildManager into build mode, allowing the player to position and build the selected buildable or cancel. The out parameter of CanBuild() is a pair that can be passed to this function.
 - OnExitedBuildMode <- Event raised when the player has exited build mode for any reason. Player could have cancelled the build or finished building.
 - OnItemPlaced <- Event raised when the player has constructed the item that was being placed. 

The controls for building are (we'll have to figure out better controls for these):
- **F** Construct the selected buildable. Resources will be automatically taken out of the inventory. 
- **Y** Cancel the build operation. Will exit build mode without removing any resources.

I have also created a special script called BuildTestScript. When attached to the player it will allow you to test placing all buildables without actually needing the resources to do so. It also gives examples of binding to the two events.

The controls that the BuildTestScript adds:
- **R** Cycle to the next buildable
- **T** Force the BuildingManager into build mode, making the cost for the item be free